### PR TITLE
Add CI to generate Debian package

### DIFF
--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -19,3 +19,9 @@ jobs:
         with:
           distro: buster
           arch: armhf
+      - name: Upload package
+        uses: danielmundi/upload-gemfury@main
+        with:
+          package-name: ${{ steps.build_debian_package.outputs.deb-package }}
+          gemfury-username: ${GEMFURY_NAME}
+          gemfury-token: ${GEMFURY_TOKEN}

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -22,12 +22,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Build Debian package
         uses: danielmundi/sbuild-debian-package@sbuild
+        id: build-debian-package
         with:
           distro: ${{ matrix.distro }}
           arch: ${{ matrix.arch }}
       - name: Upload package
         uses: danielmundi/upload-gemfury@main
         with:
-          package-name: ${{ steps.build_debian_package.outputs.deb-package }}
+          package-name: ${{ steps.build-debian-package.outputs.deb-package }}
           gemfury-username: ${GEMFURY_NAME}
           gemfury-token: ${GEMFURY_TOKEN}

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -20,15 +20,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Build Debian package
         uses: danielmundi/sbuild-debian-package@main
         id: build-debian-package
         with:
           distro: ${{ matrix.distro }}
           arch: ${{ matrix.arch }}
+
       - name: Upload package
         uses: danielmundi/upload-gemfury@main
         with:
           package-name: ${{ steps.build-debian-package.outputs.deb-package }}
-          gemfury-username: ${GEMFURY_NAME}
-          gemfury-token: ${GEMFURY_TOKEN}
+          gemfury-username: ${{ secrets.GEMFURY_NAME }}
+          gemfury-token: ${{ secrets.GEMFURY_TOKEN }}

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -1,0 +1,21 @@
+
+name: Build Debian Packages
+on:
+  push:
+    paths:
+      - 'debian/changelog'
+  pull_request:
+    paths:
+      - 'debian/changelog'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build Debian package
+        uses: danielmundi/sbuild-debian-package@sbuild
+        with:
+          distro: buster
+          arch: armhf

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -11,14 +11,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        distro: [buster]
+        arch: [armhf]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build Debian package
         uses: danielmundi/sbuild-debian-package@sbuild
         with:
-          distro: buster
-          arch: armhf
+          distro: ${{ matrix.distro }}
+          arch: ${{ matrix.arch }}
       - name: Upload package
         uses: danielmundi/upload-gemfury@main
         with:

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build Debian package
-        uses: danielmundi/sbuild-debian-package@sbuild
+        uses: danielmundi/sbuild-debian-package@main
         id: build-debian-package
         with:
           distro: ${{ matrix.distro }}

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: wlanpi-profiler
 Section: python
 Priority: extra
 Maintainer: Josh Schmelzle <josh@joshschmelzle.com>
-Build-Depends: debhelper (>= 9), python3, dh-virtualenv (>= 1.0), python3-distutils, libffi-dev
+Build-Depends: debhelper (>= 11), dh-python, dh-virtualenv (>= 1.0), python3, python3-setuptools, python3-distutils, python3-venv
 Standards-Version: 3.9.5
 X-Python3-Version: >= 3.7
 Homepage: https://github.com/WLAN-Pi/profiler


### PR DESCRIPTION
Create a Github Workflow to generate and automatically upload wlanpi-profiler package.
This is only triggered by a change on `debian/changelog`, to make sure the intent is to generate a new package and give it a proper version number.

For the upload to work, we need to setup 2 env variables on the project settings for the access token.